### PR TITLE
Parse ES2017

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+benches/js/**/* linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Some obscure syntax might not parse correctly yet. If you find a bug, please con
 - [x] ES5
 - [ ] ES2015 (ES6)
 - [x] ES2016 (ES7)
-- [ ] ES2017
+- [x] ES2017
 - [ ] ES2018
 - [ ] ES2019
 - [ ] ES2020

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -34,6 +34,8 @@ pub struct Function<'a> {
     pub params: Vec<Node<'a>>,
     /// `type: FunctionBody`
     pub body: Box<Node<'a>>,
+    #[serde(rename = "async")]
+    pub is_async: bool,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -495,6 +497,11 @@ pub enum NodeKind<'a> {
         /// `type: Expression`
         argument: Box<Node<'a>>,
         prefix: bool,
+    },
+    /// An await expression.
+    AwaitExpression {
+        /// `type: Expression`
+        argument: Box<Node<'a>>,
     },
     /*
     Expressions / Binary operations

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -120,6 +120,9 @@ fn parse_prefix_expr(s: Span) -> ParseResult<Node> {
                 arguments: arguments.unwrap_or_default(),
             }
         }
+        PrefixOperator::Await => NodeKind::AwaitExpression {
+            argument: Box::new(rhs),
+        },
     };
     Ok((s, node_kind.with_pos(start, end)))
 }
@@ -399,7 +402,10 @@ mod tests {
 
         // exponentiation (right associative)
         assert_json_snapshot!("exponentiation", parse_expr("x ** y".into()).unwrap().1);
-        assert_json_snapshot!("exponentiation-2", parse_expr("x ** y ** z".into()).unwrap().1);
+        assert_json_snapshot!(
+            "exponentiation-2",
+            parse_expr("x ** y ** z".into()).unwrap().1
+        );
     }
 
     #[test]
@@ -423,6 +429,9 @@ mod tests {
 
         assert_json_snapshot!(parse_expr("!x".into()).unwrap().1);
         assert_json_snapshot!(parse_expr("!(x && y)".into()).unwrap().1);
+
+        assert_json_snapshot!(parse_expr("await foo".into()).unwrap().1);
+        assert_json_snapshot!(parse_expr("await foo".into()).unwrap().1);
     }
 
     #[test]

--- a/src/parser/keyword.rs
+++ b/src/parser/keyword.rs
@@ -56,6 +56,7 @@ pub fn parse_future_reserved_word_lax(s: Span) -> ParseResult<()> {
         keyword_const,
         keyword_export,
         keyword_import,
+        keyword_await,
     )))(s)
 }
 
@@ -209,4 +210,11 @@ pub fn keyword_static(s: Span) -> ParseResult<()> {
 }
 pub fn keyword_yield(s: Span) -> ParseResult<()> {
     value((), pair(tag("yield"), not(identifier_continue)))(s)
+}
+// es2017
+pub fn keyword_async(s: Span) -> ParseResult<()> {
+    value((), pair(tag("async"), not(identifier_continue)))(s)
+}
+pub fn keyword_await(s: Span) -> ParseResult<()> {
+    value((), pair(tag("await"), not(identifier_continue)))(s)
 }

--- a/src/parser/literal.rs
+++ b/src/parser/literal.rs
@@ -215,6 +215,7 @@ fn parse_property_assignment(s: Span) -> ParseResult<Node> {
                             body: Box::new(body),
                             id: Box::new(None),
                             params: Vec::new(),
+                            is_async: false, // async is incompatible with get
                         },
                     }
                     .with_pos(start_func, end_func),
@@ -244,6 +245,7 @@ fn parse_property_assignment(s: Span) -> ParseResult<Node> {
                             body: Box::new(body),
                             id: Box::new(None),
                             params: vec![param],
+                            is_async: false, // async is incompatible with set
                         },
                     }
                     .with_pos(start_func, end_func),

--- a/src/parser/precedence.rs
+++ b/src/parser/precedence.rs
@@ -291,6 +291,8 @@ pub enum PrefixOperator {
     Update(UpdateOperator),
     /// Eats `new` (does not eat identifier or argument list).
     New,
+    /// `await` expression.
+    Await,
 }
 impl From<UnaryOperator> for PrefixOperator {
     fn from(op: UnaryOperator) -> Self {
@@ -354,6 +356,7 @@ pub fn parse_prefix_operator(s: Span) -> ParseResult<(PrefixOperator, BindingPow
             (UnaryOperator::Delete.into(), BindingPower(-1, 33)),
             keyword_delete,
         ),
+        value((PrefixOperator::Await, BindingPower(-1, 33)), keyword_await),
         // Mozilla docs specify precedence of 20 so binding power of 39 but callee identifier should bind to `new` instead of argument list.
         value((PrefixOperator::New, BindingPower(-1, 41)), keyword_new),
     )))(s)

--- a/src/parser/snapshots/coconut__parser__expression__tests__expr_bp_assignment-7.snap
+++ b/src/parser/snapshots/coconut__parser__expression__tests__expr_bp_assignment-7.snap
@@ -47,6 +47,7 @@ expression: "parse_expr(\"x = a ? myFunc : function () { return c; }\".into()).u
         "start": 29,
         "end": 42
       },
+      "async": false,
       "start": 17,
       "end": 42
     },

--- a/src/parser/snapshots/coconut__parser__expression__tests__expr_bp_assignment-9.snap
+++ b/src/parser/snapshots/coconut__parser__expression__tests__expr_bp_assignment-9.snap
@@ -33,6 +33,7 @@ expression: "parse_expr(\"myFunc = function () { return 0; }\".into()).unwrap().
       "start": 21,
       "end": 34
     },
+    "async": false,
     "start": 9,
     "end": 34
   },

--- a/src/parser/snapshots/coconut__parser__expression__tests__expr_bp_member_expr-8.snap
+++ b/src/parser/snapshots/coconut__parser__expression__tests__expr_bp_member_expr-8.snap
@@ -102,6 +102,7 @@ expression: "parse_expr(r#\"test\n                    .then(fn)\n               
         "start": 153,
         "end": 222
       },
+      "async": false,
       "start": 136,
       "end": 222
     }

--- a/src/parser/snapshots/coconut__parser__expression__tests__expr_bp_no_seq-2.snap
+++ b/src/parser/snapshots/coconut__parser__expression__tests__expr_bp_no_seq-2.snap
@@ -38,6 +38,7 @@ expression: "parse_expr_no_seq(\"test() ? function () { return 0; } : function()
       "start": 21,
       "end": 34
     },
+    "async": false,
     "start": 9,
     "end": 34
   },
@@ -63,6 +64,7 @@ expression: "parse_expr_no_seq(\"test() ? function () { return 0; } : function()
       "start": 48,
       "end": 61
     },
+    "async": false,
     "start": 37,
     "end": 61
   },

--- a/src/parser/snapshots/coconut__parser__expression__tests__expr_bp_prefix-10.snap
+++ b/src/parser/snapshots/coconut__parser__expression__tests__expr_bp_prefix-10.snap
@@ -1,0 +1,15 @@
+---
+source: src/parser/expression.rs
+expression: "parse_expr(\"await foo\".into()).unwrap().1"
+---
+{
+  "type": "AwaitExpression",
+  "argument": {
+    "type": "Identifier",
+    "name": "foo",
+    "start": 6,
+    "end": 9
+  },
+  "start": 0,
+  "end": 9
+}

--- a/src/parser/snapshots/coconut__parser__expression__tests__expr_bp_prefix-11.snap
+++ b/src/parser/snapshots/coconut__parser__expression__tests__expr_bp_prefix-11.snap
@@ -1,0 +1,15 @@
+---
+source: src/parser/expression.rs
+expression: "parse_expr(\"await foo\".into()).unwrap().1"
+---
+{
+  "type": "AwaitExpression",
+  "argument": {
+    "type": "Identifier",
+    "name": "foo",
+    "start": 6,
+    "end": 9
+  },
+  "start": 0,
+  "end": 9
+}

--- a/src/parser/snapshots/coconut__parser__functions__tests__async_function.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__async_function.snap
@@ -1,0 +1,60 @@
+---
+source: src/parser/functions.rs
+expression: "parse_program(r#\"async function foo(callback) {\n                    await test();\n                }\"#.into()).unwrap().1"
+---
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "FunctionDeclaration",
+      "id": {
+        "type": "Identifier",
+        "name": "foo",
+        "start": 15,
+        "end": 18
+      },
+      "params": [
+        {
+          "type": "Identifier",
+          "name": "callback",
+          "start": 19,
+          "end": 27
+        }
+      ],
+      "body": {
+        "type": "BlockStatement",
+        "body": [
+          {
+            "type": "ExpressionStatement",
+            "expression": {
+              "type": "AwaitExpression",
+              "argument": {
+                "type": "CallExpression",
+                "callee": {
+                  "type": "Identifier",
+                  "name": "test",
+                  "start": 57,
+                  "end": 61
+                },
+                "arguments": [],
+                "start": 57,
+                "end": 63
+              },
+              "start": 51,
+              "end": 63
+            },
+            "start": 51,
+            "end": 64
+          }
+        ],
+        "start": 29,
+        "end": 82
+      },
+      "async": true,
+      "start": 0,
+      "end": 82
+    }
+  ],
+  "start": 0,
+  "end": 82
+}

--- a/src/parser/snapshots/coconut__parser__functions__tests__empty_function.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__empty_function.snap
@@ -27,6 +27,7 @@ expression: "parse_program(r#\"function foo(callback) {\n                    // 
         "start": 23,
         "end": 72
       },
+      "async": false,
       "start": 0,
       "end": 72
     }

--- a/src/parser/snapshots/coconut__parser__functions__tests__function_declaration-2.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__function_declaration-2.snap
@@ -17,6 +17,7 @@ expression: "parse_function_declaration(r#\"function a() {}\"#.into()).unwrap().
     "start": 13,
     "end": 15
   },
+  "async": false,
   "start": 0,
   "end": 15
 }

--- a/src/parser/snapshots/coconut__parser__functions__tests__function_declaration-3.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__function_declaration-3.snap
@@ -30,6 +30,7 @@ expression: "parse_function_declaration(r#\"function a(param1, param2) {}\"#.int
     "start": 27,
     "end": 29
   },
+  "async": false,
   "start": 0,
   "end": 29
 }

--- a/src/parser/snapshots/coconut__parser__functions__tests__function_declaration-4.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__function_declaration-4.snap
@@ -30,6 +30,7 @@ expression: "parse_function_declaration(r#\"function a(param1, param2,) {}\"#.in
     "start": 28,
     "end": 30
   },
+  "async": false,
   "start": 0,
   "end": 30
 }

--- a/src/parser/snapshots/coconut__parser__functions__tests__function_declaration-5.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__function_declaration-5.snap
@@ -75,6 +75,7 @@ expression: "parse_function_declaration(r#\"function a() {\n                    
     "start": 13,
     "end": 190
   },
+  "async": false,
   "start": 0,
   "end": 190
 }

--- a/src/parser/snapshots/coconut__parser__functions__tests__function_declaration-6.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__function_declaration-6.snap
@@ -159,6 +159,7 @@ expression: "parse_function_declaration(r#\"function fib() {\n                  
     "start": 15,
     "end": 182
   },
+  "async": false,
   "start": 0,
   "end": 182
 }

--- a/src/parser/snapshots/coconut__parser__functions__tests__function_declaration-7.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__function_declaration-7.snap
@@ -20,6 +20,7 @@ expression: "parse_program(r#\"function foo() {\n                    // stuff\n 
         "start": 15,
         "end": 63
       },
+      "async": false,
       "start": 0,
       "end": 63
     },

--- a/src/parser/snapshots/coconut__parser__functions__tests__function_declaration.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__function_declaration.snap
@@ -41,6 +41,7 @@ expression: "parse_function_declaration(r#\"function a() {\n                    
     "start": 13,
     "end": 94
   },
+  "async": false,
   "start": 0,
   "end": 94
 }

--- a/src/parser/snapshots/coconut__parser__functions__tests__function_expr-2.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__function_expr-2.snap
@@ -40,6 +40,7 @@ expression: "parse_function_declaration(r#\"function a() {\n                    
                 "start": 94,
                 "end": 96
               },
+              "async": false,
               "start": 81,
               "end": 96
             }
@@ -54,6 +55,7 @@ expression: "parse_function_declaration(r#\"function a() {\n                    
     "start": 13,
     "end": 114
   },
+  "async": false,
   "start": 0,
   "end": 114
 }

--- a/src/parser/snapshots/coconut__parser__functions__tests__function_expr.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__function_expr.snap
@@ -44,6 +44,7 @@ expression: "parse_function_declaration(r#\"function a() {\n                    
             "start": 91,
             "end": 143
           },
+          "async": false,
           "start": 79,
           "end": 143
         },
@@ -54,6 +55,7 @@ expression: "parse_function_declaration(r#\"function a() {\n                    
     "start": 13,
     "end": 162
   },
+  "async": false,
   "start": 0,
   "end": 162
 }

--- a/src/parser/snapshots/coconut__parser__functions__tests__nested_function_declaration.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__nested_function_declaration.snap
@@ -47,6 +47,7 @@ expression: "parse_function_declaration(r#\"function a() {\n                    
           "start": 48,
           "end": 100
         },
+        "async": false,
         "start": 35,
         "end": 100
       }
@@ -54,6 +55,7 @@ expression: "parse_function_declaration(r#\"function a() {\n                    
     "start": 13,
     "end": 118
   },
+  "async": false,
   "start": 0,
   "end": 118
 }

--- a/src/parser/snapshots/coconut__parser__functions__tests__parse_immediately_invoked_function_expr.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__parse_immediately_invoked_function_expr.snap
@@ -28,6 +28,7 @@ expression: "parse_stmt(r#\"(function () {\n                    123; // somethin
         "start": 13,
         "end": 70
       },
+      "async": false,
       "start": 1,
       "end": 70
     },

--- a/src/parser/snapshots/coconut__parser__functions__tests__parse_program_immediately_invoked_function_expr-2.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__parse_program_immediately_invoked_function_expr-2.snap
@@ -284,6 +284,7 @@ expression: "parse_program(r#\"(function (global, factory) {\n                  
             "start": 28,
             "end": 334
           },
+          "async": false,
           "start": 1,
           "end": 334
         },
@@ -310,6 +311,7 @@ expression: "parse_program(r#\"(function (global, factory) {\n                  
               "start": 361,
               "end": 363
             },
+            "async": false,
             "start": 342,
             "end": 363
           }

--- a/src/parser/snapshots/coconut__parser__functions__tests__parse_program_immediately_invoked_function_expr.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__parse_program_immediately_invoked_function_expr.snap
@@ -31,6 +31,7 @@ expression: "parse_program(r#\"(function () {\n                    123; // somet
             "start": 13,
             "end": 70
           },
+          "async": false,
           "start": 1,
           "end": 70
         },

--- a/src/parser/snapshots/coconut__parser__functions__tests__program-2.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__program-2.snap
@@ -76,6 +76,7 @@ expression: "parse_program(r#\"var x = 1;\n                function foo() {\n   
         "start": 42,
         "end": 146
       },
+      "async": false,
       "start": 27,
       "end": 146
     }

--- a/src/parser/snapshots/coconut__parser__functions__tests__program-3.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__program-3.snap
@@ -162,6 +162,7 @@ expression: "parse_program(r#\"\n                function fib() {\n             
         "start": 32,
         "end": 199
       },
+      "async": false,
       "start": 17,
       "end": 199
     },

--- a/src/parser/snapshots/coconut__parser__functions__tests__program-4.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__program-4.snap
@@ -49,6 +49,7 @@ expression: "parse_program(r#\"function foo() {\n                    test;\n    
         "start": 15,
         "end": 149
       },
+      "async": false,
       "start": 0,
       "end": 149
     }

--- a/src/parser/snapshots/coconut__parser__functions__tests__program.snap
+++ b/src/parser/snapshots/coconut__parser__functions__tests__program.snap
@@ -57,6 +57,7 @@ expression: "parse_program(r#\"var x = 1;\n                function foo() {\n   
         "start": 42,
         "end": 91
       },
+      "async": false,
       "start": 27,
       "end": 91
     }

--- a/src/parser/snapshots/coconut__parser__literal__tests__obj_lit-5.snap
+++ b/src/parser/snapshots/coconut__parser__literal__tests__obj_lit-5.snap
@@ -35,6 +35,7 @@ expression: "parse_literal(r#\"{\n                    test: function () {\n     
           "start": 40,
           "end": 98
         },
+        "async": false,
         "start": 28,
         "end": 98
       },

--- a/src/parser/snapshots/coconut__parser__literal__tests__obj_lit-6.snap
+++ b/src/parser/snapshots/coconut__parser__literal__tests__obj_lit-6.snap
@@ -35,6 +35,7 @@ expression: "parse_literal(r#\"{\n                    get: function () {\n      
           "start": 39,
           "end": 97
         },
+        "async": false,
         "start": 27,
         "end": 97
       },

--- a/src/parser/snapshots/coconut__parser__literal__tests__obj_lit-7.snap
+++ b/src/parser/snapshots/coconut__parser__literal__tests__obj_lit-7.snap
@@ -49,6 +49,7 @@ expression: "parse_literal(r#\"{\n                    get: test() ? function () 
             "start": 48,
             "end": 105
           },
+          "async": false,
           "start": 36,
           "end": 105
         },
@@ -74,6 +75,7 @@ expression: "parse_literal(r#\"{\n                    get: test() ? function () 
             "start": 120,
             "end": 177
           },
+          "async": false,
           "start": 108,
           "end": 177
         },

--- a/src/parser/snapshots/coconut__parser__literal__tests__obj_lit_getter_setter.snap
+++ b/src/parser/snapshots/coconut__parser__literal__tests__obj_lit_getter_setter.snap
@@ -35,6 +35,7 @@ expression: "parse_literal(r#\"{\n                    get a() {\n               
           "start": 30,
           "end": 80
         },
+        "async": false,
         "start": 27,
         "end": 80
       },
@@ -79,6 +80,7 @@ expression: "parse_literal(r#\"{\n                    get a() {\n               
           "start": 111,
           "end": 161
         },
+        "async": false,
         "start": 107,
         "end": 161
       },

--- a/src/parser/snapshots/coconut__parser__statement__tests__expr_stmt_immediately_invoked_function_expr-2.snap
+++ b/src/parser/snapshots/coconut__parser__statement__tests__expr_stmt_immediately_invoked_function_expr-2.snap
@@ -47,6 +47,7 @@ expression: "parse_stmt(\"(function (x) {\n            return x * x;\n        })
         "start": 14,
         "end": 51
       },
+      "async": false,
       "start": 1,
       "end": 51
     },

--- a/src/parser/snapshots/coconut__parser__statement__tests__expr_stmt_immediately_invoked_function_expr.snap
+++ b/src/parser/snapshots/coconut__parser__statement__tests__expr_stmt_immediately_invoked_function_expr.snap
@@ -28,6 +28,7 @@ expression: "parse_stmt(\"(function () {\n            return 0;\n        })();\"
         "start": 13,
         "end": 46
       },
+      "async": false,
       "start": 1,
       "end": 46
     },


### PR DESCRIPTION
Changes include parsing for:
* `async function` declarations
* `async function` expressions
* `await` expressions

*Note*:
ES2015 (ES6) has still not been implemented yet. Once ES2015 is implemented, `async` must be parsed for arrow functions as well.